### PR TITLE
Revert "Bump rollup-plugin-typescript2 from 0.24.3 to 0.25.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-serve": "^1.0.1",
     "rollup-plugin-terser": "^5.1.2",
-    "rollup-plugin-typescript2": "^0.25.1",
+    "rollup-plugin-typescript2": "^0.24.3",
     "rollup-plugin-uglify": "^6.0.2",
     "typescript": "^3.6.4"
   }


### PR DESCRIPTION
Reverts hacs/frontend#9