### PR TITLE
Add search to sections

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "printWidth": 100
+}

--- a/src/components/dialogs/hacs-add-repository-dialog.ts
+++ b/src/components/dialogs/hacs-add-repository-dialog.ts
@@ -68,7 +68,7 @@ export class HacsAddRepositoryDialog extends HacsDialogBase {
         this.repositories,
         this.configuration?.categories
       ),
-      this._searchInput?.toLocaleLowerCase()
+      this._searchInput
     );
 
     return html`

--- a/src/components/dialogs/hacs-add-repository-dialog.ts
+++ b/src/components/dialogs/hacs-add-repository-dialog.ts
@@ -15,6 +15,7 @@ import { Repository } from "../../data/common";
 
 import { localize } from "../../localize/localize";
 import { sections } from "../../panels/hacs-sections";
+import { filterRepositoriesByInput } from "../../tools/filter-repositories-by-input";
 import "../hacs-search";
 import "../hacs-chip";
 
@@ -56,18 +57,7 @@ export class HacsAddRepositoryDialog extends HacsDialogBase {
       )
   );
 
-  private _filterRepositories = memoizeOne(
-    (repositories: Repository[], filter: string) =>
-      repositories?.filter(
-        (repo) =>
-          repo.name?.toLocaleLowerCase().includes(filter) ||
-          repo.description?.toLocaleLowerCase().includes(filter) ||
-          repo.category.toLocaleLowerCase().includes(filter) ||
-          repo.full_name.toLocaleLowerCase().includes(filter) ||
-          String(repo.authors)?.toLocaleLowerCase().includes(filter) ||
-          repo.domain?.toLocaleLowerCase().includes(filter)
-      )
-  );
+  private _filterRepositories = memoizeOne(filterRepositoriesByInput);
 
   protected render(): TemplateResult | void {
     this._searchInput = window.localStorage.getItem("hacs-search") || "";

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -157,6 +157,8 @@
     "no_repositories": "No repositories",
     "no_repositories_desc1": "It seems like you don't have any repositories installed in this section yet.",
     "no_repositories_desc2": "Click on the + in the bottom corner to add your first!",
+    "no_repositories_found_desc1": "No repositories matching \"{searchInput}\" found.",
+    "no_repositories_found_desc2": "Try searching for something else!",
     "new_repositories": "New Repositories",
     "pending_upgrades": "Pending upgrades",
     "placeholder_search": "Please enter a search term...",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -157,7 +157,7 @@
     "no_repositories": "No repositories",
     "no_repositories_desc1": "It seems like you don't have any repositories installed in this section yet.",
     "no_repositories_desc2": "Click on the + in the bottom corner to add your first!",
-    "no_repositories_found_desc1": "No repositories matching \"{searchInput}\" found.",
+    "no_repositories_found_desc1": "No installed repositories matching \"{searchInput}\" found in this section.",
     "no_repositories_found_desc2": "Try searching for something else!",
     "new_repositories": "New Repositories",
     "pending_upgrades": "Pending upgrades",

--- a/src/panels/hacs-store-panel.ts
+++ b/src/panels/hacs-store-panel.ts
@@ -12,6 +12,7 @@ import { localize } from "../localize/localize";
 import { HacsStyles } from "../styles/hacs-common-style";
 import { sections } from "./hacs-sections";
 import { addedToLovelace } from "../tools/added-to-lovelace";
+import { filterRepositoriesByInput } from "../tools/filter-repositories-by-input";
 
 @customElement("hacs-store-panel")
 export class HacsStorePanel extends LitElement {
@@ -63,10 +64,10 @@ export class HacsStorePanel extends LitElement {
     return newRepositories.concat(installedRepositories);
   }
 
+  private _filterRepositories = memoizeOne(filterRepositoriesByInput);
+
   private get visibleRepositories(): Repository[] {
-    return this.allRepositories.filter(
-      (repo) => repo.name.toLowerCase().indexOf(this._searchInput.toLowerCase()) > -1
-    );
+    return this._filterRepositories(this.allRepositories, this._searchInput)
   }
 
   protected render(): TemplateResult {

--- a/src/panels/hacs-store-panel.ts
+++ b/src/panels/hacs-store-panel.ts
@@ -1,21 +1,8 @@
-import {
-  LitElement,
-  customElement,
-  property,
-  html,
-  css,
-  TemplateResult,
-} from "lit-element";
+import { LitElement, customElement, property, html, css, TemplateResult } from "lit-element";
 import memoizeOne from "memoize-one";
 
 import { HomeAssistant } from "custom-card-helpers";
-import {
-  Route,
-  Status,
-  Configuration,
-  Repository,
-  LovelaceResource,
-} from "../data/common";
+import { Route, Status, Configuration, Repository, LovelaceResource } from "../data/common";
 import "../layout/hacs-tabbed-layout";
 import "../components/hacs-repository-card";
 import "../components/hacs-search";
@@ -28,6 +15,7 @@ import { addedToLovelace } from "../tools/added-to-lovelace";
 
 @customElement("hacs-store-panel")
 export class HacsStorePanel extends LitElement {
+  @property() private _searchInput: string = "";
   @property({ attribute: false }) public configuration: Configuration;
   @property({ attribute: false }) public hass!: HomeAssistant;
   @property({ attribute: false }) public narrow!: boolean;
@@ -57,27 +45,36 @@ export class HacsStorePanel extends LitElement {
     }
   );
 
-  private _panelsEnabled = memoizeOne(
-    (sections: any, config: Configuration) => {
-      return sections.panels.filter((panel) => {
-        const categories = panel.categories;
-        if (categories === undefined) return true;
-        return (
-          categories.filter((c) => config?.categories.includes(c)).length !== 0
-        );
-      });
-    }
-  );
+  private _panelsEnabled = memoizeOne((sections: any, config: Configuration) => {
+    return sections.panels.filter((panel) => {
+      const categories = panel.categories;
+      if (categories === undefined) return true;
+      return categories.filter((c) => config?.categories.includes(c)).length !== 0;
+    });
+  });
 
-  protected render(): TemplateResult | void {
-    const [
-      InstalledRepositories,
-      newRepositories,
-    ] = this._repositoriesInActiveSection(
+  private get allRepositories(): Repository[] {
+    const [installedRepositories, newRepositories] = this._repositoriesInActiveSection(
       this.repositories,
       sections,
       this.section
     );
+
+    return newRepositories.concat(installedRepositories);
+  }
+
+  private get visibleRepositories(): Repository[] {
+    return this.allRepositories.filter(
+      (repo) => repo.name.toLowerCase().indexOf(this._searchInput.toLowerCase()) > -1
+    );
+  }
+
+  protected render(): TemplateResult {
+    const newRepositories = this._repositoriesInActiveSection(
+      this.repositories,
+      sections,
+      this.section
+    )[1];
 
     const tabs = this._panelsEnabled(sections, this.configuration);
 
@@ -104,32 +101,14 @@ export class HacsStorePanel extends LitElement {
             ${localize("store.new_repositories_note")}
           </div>`
         : ""}
+
+      <hacs-search .input=${this._searchInput} @input=${this._inputValueChanged}></hacs-search>
       <div class="content">
-        ${newRepositories?.concat(InstalledRepositories).length !== 0
-          ? newRepositories
-              ?.concat(InstalledRepositories)
-              ?.map(
-                (repo) =>
-                  html`<hacs-repository-card
-                    .hass=${this.hass}
-                    .repository=${repo}
-                    .narrow=${this.narrow}
-                    .status=${this.status}
-                    .addedToLovelace=${addedToLovelace(
-                      this.lovelace,
-                      this.configuration,
-                      repo
-                    )}
-                  ></hacs-repository-card>`
-              )
-          : html`<ha-card class="no-repositories">
-              <div class="header">${localize("store.no_repositories")} 😕</div>
-              <p>
-                ${localize("store.no_repositories_desc1")}<br />${localize(
-                  "store.no_repositories_desc2"
-                )}
-              </p>
-            </ha-card>`}
+        ${this.allRepositories.length === 0
+          ? this.renderEmpty()
+          : this.visibleRepositories.length === 0
+          ? this.renderNotFound()
+          : this.renderRepositories()}
       </div>
       <hacs-fab
         .narrow=${this.narrow}
@@ -139,6 +118,43 @@ export class HacsStorePanel extends LitElement {
       >
       </hacs-fab>
     </hacs-tabbed-layout>`;
+  }
+
+  private renderRepositories(): TemplateResult[] {
+    return this.visibleRepositories.map(
+      (repo) =>
+        html`<hacs-repository-card
+          .hass=${this.hass}
+          .repository=${repo}
+          .narrow=${this.narrow}
+          .status=${this.status}
+          .addedToLovelace=${addedToLovelace(this.lovelace, this.configuration, repo)}
+        ></hacs-repository-card>`
+    );
+  }
+
+  private renderNotFound(): TemplateResult {
+    return html`<ha-card class="no-repositories">
+      <div class="header">${localize("store.no_repositories")} 😕</div>
+      <p>
+        ${localize("store.no_repositories_found_desc1").replace("{searchInput}", this._searchInput)}
+        <br />
+        ${localize("store.no_repositories_found_desc2")}
+      </p>
+    </ha-card>`;
+  }
+
+  private renderEmpty(): TemplateResult {
+    return html`<ha-card class="no-repositories">
+      <div class="header">${localize("store.no_repositories")} 😕</div>
+      <p>
+        ${localize("store.no_repositories_desc1")}<br />${localize("store.no_repositories_desc2")}
+      </p>
+    </ha-card>`;
+  }
+
+  private _inputValueChanged(ev: any) {
+    this._searchInput = ev.target.input;
   }
 
   private _addRepository() {

--- a/src/panels/hacs-store-panel.ts
+++ b/src/panels/hacs-store-panel.ts
@@ -107,7 +107,7 @@ export class HacsStorePanel extends LitElement {
         ${this.allRepositories.length === 0
           ? this.renderEmpty()
           : this.visibleRepositories.length === 0
-          ? this.renderNotFound()
+          ? this.renderNoResultsFound()
           : this.renderRepositories()}
       </div>
       <hacs-fab
@@ -133,7 +133,7 @@ export class HacsStorePanel extends LitElement {
     );
   }
 
-  private renderNotFound(): TemplateResult {
+  private renderNoResultsFound(): TemplateResult {
     return html`<ha-card class="no-repositories">
       <div class="header">${localize("store.no_repositories")} 😕</div>
       <p>

--- a/src/tools/filter-repositories-by-input.ts
+++ b/src/tools/filter-repositories-by-input.ts
@@ -1,7 +1,7 @@
 import { Repository } from "../data/common";
 
 export function filterRepositoriesByInput(repositories: Repository[], filter: string): Repository[] {
-  const lowcaseFilter = filter.toLowerCase();
+  const lowcaseFilter = filter.toLocaleLowerCase();
   return repositories.filter(
     (repo) =>
       repo.name?.toLocaleLowerCase().includes(lowcaseFilter) ||

--- a/src/tools/filter-repositories-by-input.ts
+++ b/src/tools/filter-repositories-by-input.ts
@@ -1,0 +1,13 @@
+import { Repository } from "../data/common";
+
+export function filterRepositoriesByInput(repositories: Repository[], filter: string): Repository[] {
+  return repositories.filter(
+    (repo) =>
+      repo.name?.toLocaleLowerCase().includes(filter) ||
+      repo.description?.toLocaleLowerCase().includes(filter) ||
+      repo.category.toLocaleLowerCase().includes(filter) ||
+      repo.full_name.toLocaleLowerCase().includes(filter) ||
+      String(repo.authors)?.toLocaleLowerCase().includes(filter) ||
+      repo.domain?.toLocaleLowerCase().includes(filter)
+  );
+}

--- a/src/tools/filter-repositories-by-input.ts
+++ b/src/tools/filter-repositories-by-input.ts
@@ -1,13 +1,14 @@
 import { Repository } from "../data/common";
 
 export function filterRepositoriesByInput(repositories: Repository[], filter: string): Repository[] {
+  const lowcaseFilter = filter.toLowerCase();
   return repositories.filter(
     (repo) =>
-      repo.name?.toLocaleLowerCase().includes(filter) ||
-      repo.description?.toLocaleLowerCase().includes(filter) ||
-      repo.category.toLocaleLowerCase().includes(filter) ||
-      repo.full_name.toLocaleLowerCase().includes(filter) ||
-      String(repo.authors)?.toLocaleLowerCase().includes(filter) ||
-      repo.domain?.toLocaleLowerCase().includes(filter)
+      repo.name?.toLocaleLowerCase().includes(lowcaseFilter) ||
+      repo.description?.toLocaleLowerCase().includes(lowcaseFilter) ||
+      repo.category.toLocaleLowerCase().includes(lowcaseFilter) ||
+      repo.full_name.toLocaleLowerCase().includes(lowcaseFilter) ||
+      String(repo.authors)?.toLocaleLowerCase().includes(lowcaseFilter) ||
+      repo.domain?.toLocaleLowerCase().includes(lowcaseFilter)
   );
 }


### PR DESCRIPTION
## Overview 

Adds search capabilities to the HACS store panels. ~~As a first version, search is basic - searches only by repository name.~~ Uses the same search function as the Add Repository dialog

Changes:
- Add `ha-search` to `hacs-store-panel`
- Add "No results found" empty state + localization. empty state always takes precedence over no results found state
- Refactor `hacs-store-panel`'s render into 3 separate methods. This is a little bit subjective, but I think components are easier to read like this.
- Add `.prettierrc` file - my editor defaults to single quotes, so I thought this is useful. Let me know what you think and if I should change the print width.

## Screenshots (with Noctis theme)

No search:
![image](https://user-images.githubusercontent.com/2514425/83439005-fbf69d80-a44a-11ea-80a7-80e8a7a398c9.png)

With search results:
![image](https://user-images.githubusercontent.com/2514425/83439061-14ff4e80-a44b-11ea-9055-0b23238034c8.png)

Empty state:
![image](https://user-images.githubusercontent.com/2514425/83439550-0e250b80-a44c-11ea-8bbe-38064eeaedef.png)

