### PR TITLE
Correction in english language file

### DIFF
--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -231,7 +231,7 @@
     "installed_version": "Installed version",
     "available_version": "Available version",
     "changelog": "Changelog",
-    "releasenotes": "Releasenotes for {release}"
+    "releasenotes": "Release notes for {release}"
   },
   "repository_card": {
     "pending_update": "Pending update",


### PR DESCRIPTION
I was just a bit annoyed on the missing space in `Releasenotes` so I corrected it.

(my smallest PR change in my history of github)

Also, keep up the great work @ludeeus!