### PR TITLE
Adjust screen grid to look more like the addon screen

### DIFF
--- a/src/components/hacs-repository-card.ts
+++ b/src/components/hacs-repository-card.ts
@@ -276,7 +276,6 @@ export class HacsRepositoryCard extends LitElement {
           display: flex;
           flex-direction: column;
           height: 100%;
-          width: 480px;
           border-style: solid;
           border-width: min(var(--ha-card-border-width, 1px), 10px);
           border-color: transparent;

--- a/src/panels/hacs-store-panel.ts
+++ b/src/panels/hacs-store-panel.ts
@@ -233,7 +233,7 @@ export class HacsStorePanel extends LitElement {
           border-bottom: 1px solid var(--divider-color);
         }
         .content {
-          height: calc(100vh - 128px);
+          height: calc(100vh - 115px);
           overflow: auto;
         }
         .narrow-content {
@@ -241,11 +241,9 @@ export class HacsStorePanel extends LitElement {
         }
         .container {
           display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));
-          justify-items: center;
+          grid-template-columns: repeat(auto-fit, minmax(300px, 0.25fr));
           grid-gap: 8px 8px;
-          padding: 8px 16px 16px;
-          margin-bottom: 64px;
+          margin: 8px;
         }
         .no-repositories {
           width: 100%;
@@ -261,6 +259,7 @@ export class HacsStorePanel extends LitElement {
           display: flex;
           flex-direction: column;
           justify-content: space-between;
+          width: 100%;
         }
         hacs-repository-card[narrow] {
           width: 100%;


### PR DESCRIPTION
Currently the store grid layout looks like this:

![Screenshot_2020 11 16_00h39m51s_012_](https://user-images.githubusercontent.com/1368405/99200292-b897ad80-27a4-11eb-99b2-6135642a4ec5.png)
![Screenshot_2020 11 16_00h43m59s_013_](https://user-images.githubusercontent.com/1368405/99200307-d238f500-27a4-11eb-9ec4-a0e3649f344e.png)


I tried to improve it by adapting the supervisor addon style (start from the left top corner and space the items equally with 1/4 of the width):
![Screenshot_2020 11 16_00h39m08s_011_](https://user-images.githubusercontent.com/1368405/99200290-b5042680-27a4-11eb-8a0e-9645884ed01d.png)
![Screenshot_2020 11 16_01h09m12s_014_](https://user-images.githubusercontent.com/1368405/99200887-5a6cc980-27a8-11eb-8484-b6fdd0beae21.png)


Now the single items (especially if there are only a few) don't have this strange space around them and are aligned on the top left instead of somewhere in the middle. 

To be honest I did not test this beyond the css editor in the dev console of my browser, so I can't ensure, that this does 100% work. Also I'm not quite sure, what the `narrow` flag is, if the narrow style is affected by this change and how to activate it. I couldn't find anything in the docs about this flag. 
That's the reason why I set this PR as a draft. So mainly it would be great to get feedback first on the change in general. Thanks!
