### PR TITLE
Update en.json to fix small grammar error

### DIFF
--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -327,7 +327,7 @@
       },
       "restart": {
         "title": "Pending restart",
-        "content": "You have {number} {pluralWording} that requires a restart of Home Assistant, you can do that from the 'Server Controls' section under the configuration part of Home Assistant UI."
+        "content": "You have {number} {pluralWording} for which a restart of Home Assistant is required. You can do that from the 'Server Controls' section under the configuration part of Home Assistant UI."
       },
       "removed": "Removed repository '{repository}'"
     },


### PR DESCRIPTION
To prevent a grammar error in the following sentence "You have 3 Integrations that requires a restart of Home Assistant, you can do that from the 'Server Controls' section under the configuration part of Home Assistant UI."