### PR TITLE
Shorten markdown github commits links

### DIFF
--- a/src/tools/markdown/markdown.ts
+++ b/src/tools/markdown/markdown.ts
@@ -58,6 +58,13 @@ export class markdown {
         .replace("/blob/", "/");
       return url;
     });
+
+    // Shorten commits links
+    input = input.replace(/(https:\/\/github\.com\/\S*\/commit\/[0-9a-f]{40})/g, function (x) {
+      let hash = x.substr(x.length - 40, 7);
+      return `[\`${hash}\`](${x})`;
+    });
+
     const content = document.createElement("div");
     content.className = "markdown-body";
     content.innerHTML = DOMPurify.sanitize(marked(input), {

--- a/src/tools/markdown/markdown.ts
+++ b/src/tools/markdown/markdown.ts
@@ -60,9 +60,9 @@ export class markdown {
     });
 
     // Shorten commits links
-    input = input.replace(/(https:\/\/github\.com\/\S*\/commit\/[0-9a-f]{40})/g, function (x) {
-      const hash = x.substr(x.length - 40, 7);
-      return `[\`${hash}\`](${x})`;
+    input = input.replace(/https:\/\/github\.com\/\S*\/commit\/([0-9a-f]{40})/g, (url, commit) => {
+      const hash = commit.substr(0, 7);
+      return `[\`${hash}\`](${url})`;
     });
 
     const content = document.createElement("div");

--- a/src/tools/markdown/markdown.ts
+++ b/src/tools/markdown/markdown.ts
@@ -61,7 +61,7 @@ export class markdown {
 
     // Shorten commits links
     input = input.replace(/(https:\/\/github\.com\/\S*\/commit\/[0-9a-f]{40})/g, function (x) {
-      let hash = x.substr(x.length - 40, 7);
+      const hash = x.substr(x.length - 40, 7);
       return `[\`${hash}\`](${x})`;
     });
 


### PR DESCRIPTION
Github shortens all commit links to the first 7 characters of hash like that:
`https://github.com/hacs/frontend/commit/ecc46f369d8cfb96d33f5cc41e640dfdb4921da7` -> https://github.com/hacs/frontend/commit/ecc46f369d8cfb96d33f5cc41e640dfdb4921da7
This PR adds the same functionality to HACS. This change will affect all components using `markdown.html()`.

Before:
![image](https://user-images.githubusercontent.com/23432278/118865148-f3f46f80-b8e0-11eb-9d6a-76c7f5b0e536.png)

After:
![image](https://user-images.githubusercontent.com/23432278/118865036-d7583780-b8e0-11eb-842d-f95c0312dece.png)