### PR TITLE
Add hacstag to lovelace resource URL's

### DIFF
--- a/src/components/hacs-repository-card.ts
+++ b/src/components/hacs-repository-card.ts
@@ -1,25 +1,26 @@
+import "@material/mwc-button/mwc-button";
+import { mdiDotsVertical } from "@mdi/js";
+import "@polymer/paper-item/paper-item";
+import "@polymer/paper-item/paper-item-body";
 import "@polymer/paper-listbox/paper-listbox";
 import "@polymer/paper-menu-button/paper-menu-button";
-import "@material/mwc-button/mwc-button";
-import "@polymer/paper-item/paper-item-body";
-import "@polymer/paper-item/paper-item";
-import "./hacs-chip";
-import "../../homeassistant-frontend/src/components/ha-card";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
-import { classMap, ClassInfo } from "lit/directives/class-map";
-import { HacsStyles } from "../styles/hacs-common-style";
-import { Repository, Status, RemovedRepository } from "../data/common";
+import { ClassInfo, classMap } from "lit/directives/class-map";
+import "../../homeassistant-frontend/src/components/ha-card";
+import { HomeAssistant } from "../../homeassistant-frontend/src/types";
+import { RemovedRepository, Repository, Status } from "../data/common";
 import { Hacs } from "../data/hacs";
 import {
+  deleteResource,
+  fetchResources,
   repositorySetNotNew,
   repositoryUninstall,
   repositoryUpdate,
-  deleteResource,
-  fetchResources,
 } from "../data/websocket";
-import { HomeAssistant } from "../../homeassistant-frontend/src/types";
-import { mdiDotsVertical } from "@mdi/js";
+import { HacsStyles } from "../styles/hacs-common-style";
+import { generateLovelaceURL } from "../tools/added-to-lovelace";
+import "./hacs-chip";
 import { hacsIcon } from "./hacs-icon";
 import "./hacs-link";
 
@@ -216,10 +217,6 @@ export class HacsRepositoryCard extends LitElement {
     );
   }
 
-  private _lovelaceUrl(): string {
-    return `/hacsfiles/${this.repository?.full_name.split("/")[1]}/${this.repository?.file_name}`;
-  }
-
   private async _updateRepository() {
     this.dispatchEvent(
       new CustomEvent("hacs-dialog", {
@@ -251,10 +248,11 @@ export class HacsRepositoryCard extends LitElement {
   }
 
   private async _uninstallRepository() {
-    if (this.repository.category === "plugin" && this.hacs.status.lovelace_mode !== "yaml") {
+    if (this.repository.category === "plugin" && this.hacs.status?.lovelace_mode !== "yaml") {
       const resources = await fetchResources(this.hass);
+      const expectedURL = generateLovelaceURL(this.repository);
       resources
-        .filter((resource) => resource.url === this._lovelaceUrl())
+        .filter((resource) => expectedURL.includes(resource.url))
         .forEach((resource) => {
           deleteResource(this.hass, String(resource.id));
         });

--- a/src/components/hacs-repository-card.ts
+++ b/src/components/hacs-repository-card.ts
@@ -251,11 +251,11 @@ export class HacsRepositoryCard extends LitElement {
     if (this.repository.category === "plugin" && this.hacs.status?.lovelace_mode !== "yaml") {
       const resources = await fetchResources(this.hass);
       const expectedURL = generateLovelaceURL(this.repository);
-      resources
-        .filter((resource) => expectedURL.includes(resource.url))
-        .forEach((resource) => {
-          deleteResource(this.hass, String(resource.id));
-        });
+      await Promise.all(
+        resources
+          .filter((resource) => expectedURL.includes(resource.url))
+          .map((resource) => deleteResource(this.hass, String(resource.id)))
+      );
     }
     await repositoryUninstall(this.hass, this.repository.id);
   }

--- a/src/tools/added-to-lovelace.ts
+++ b/src/tools/added-to-lovelace.ts
@@ -1,20 +1,31 @@
 import { Repository } from "../data/common";
 import { Hacs } from "../data/hacs";
 
-export const lovelaceURL = (repository: Repository) => {
-  return `/hacsfiles/${repository?.full_name.split("/")[1]}/${repository?.file_name}`;
-};
+const generateUniqueTag = (repository: Repository, version?: string): string =>
+  String(
+    `${repository.id}${(
+      version ||
+      repository.installed_version ||
+      repository.selected_tag ||
+      repository.available_version
+    ).replace(/\D+/g, "")}`
+  );
 
-export const addedToLovelace = (hacs: Hacs, repository: Repository) => {
-  if (hacs.status?.lovelace_mode !== "storage") {
-    return true;
-  }
+export const generateLovelaceURL = (repository: Repository, version?: string): string =>
+  `/hacsfiles/${repository.full_name.split("/")[1]}/${
+    repository.file_name
+  }?hacstag=${generateUniqueTag(repository, version)}`;
+
+export const addedToLovelace = (hacs: Hacs, repository: Repository): boolean => {
   if (!repository.installed) {
     return true;
   }
   if (repository.category !== "plugin") {
     return true;
   }
-  const url = `/hacsfiles/${repository?.full_name.split("/")[1]}/${repository?.file_name}`;
-  return hacs.resources?.map((resource) => resource.url).includes(url);
+  if (hacs.status?.lovelace_mode !== "storage") {
+    return true;
+  }
+  const expectedUrl = generateLovelaceURL(repository);
+  return hacs.resources?.some((resource) => expectedUrl.includes(resource.url)) || false;
 };

--- a/src/tools/update-lovelace-resources.ts
+++ b/src/tools/update-lovelace-resources.ts
@@ -1,17 +1,19 @@
 import { HomeAssistant } from "../../homeassistant-frontend/src/types";
 import { Repository } from "../data/common";
 import { createResource, fetchResources, updateResource } from "../data/websocket";
+import { generateLovelaceURL } from "./added-to-lovelace";
 
 import { HacsLogger } from "./hacs-logger";
 
 export async function updateLovelaceResources(
   hass: HomeAssistant,
-  repository: Repository
+  repository: Repository,
+  version?: string
 ): Promise<void> {
   const logger = new HacsLogger();
   const resources = await fetchResources(hass);
   const namespace = `/hacsfiles/${repository.full_name.split("/")[1]}`;
-  const url = `${namespace}/${repository.file_name}`;
+  const url = generateLovelaceURL(repository, version);
   const exsisting = resources.find((resource) => resource.url.includes(namespace));
 
   logger.debug({ namespace, url, exsisting }, "updateLovelaceResources");


### PR DESCRIPTION
When a user are in storage mode, HACS injects the resource URL.
Even if /hacsfiles are served without cache, with the resent changes in chrome serviceworkers, they would still need to hard reload the page (often multiple times) to use the new "version" of a card/strategy/other for lovelace.


This changes the format for the resource url from `/hacsfiles/<resource-name>/<filename>.js` to `/hacsfiles/<resource-name>/<filename>.js?hacstag=<repoid><numberified-version>`


CC @thomasloven 