### PR TITLE
Remove white background from markdown images

### DIFF
--- a/src/tools/markdown/styles.ts
+++ b/src/tools/markdown/styles.ts
@@ -826,7 +826,6 @@ export const GFM3 = `
   .markdown-body img {
     max-width: 100%;
     box-sizing: initial;
-    background-color: #fff;
     border-radius: var(--ha-card-border-radius);
   }
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/23432278/121775722-a094da80-cb89-11eb-9d20-c5b5f26632ed.png)


After:

![image](https://user-images.githubusercontent.com/23432278/121775715-9246be80-cb89-11eb-962a-c7240e547b38.png)
