### PR TITLE
Improve loading screen for repository info

### DIFF
--- a/src/components/dialogs/hacs-repository-info-dialog.ts
+++ b/src/components/dialogs/hacs-repository-info-dialog.ts
@@ -71,49 +71,54 @@ export class HacsRepositoryDialog extends HacsDialogBase {
         .title=${this._repository.name || ""}
         .hass=${this.hass}
         ><div class="content scroll">
-          <div class="chips">
-            ${this._repository.installed
-              ? html`<hacs-chip
-                  title="${this.hacs.localize("dialog_info.version_installed")}"
-                  .icon=${mdiCube}
-                  .value=${this._repository.installed_version}
-                ></hacs-chip>`
-              : ""}
-            ${authors
-              ? authors.map(
-                  (author) => html`<hacs-chip
-                    title="${this.hacs.localize("dialog_info.author")}"
-                    .url="https://github.com/${author}"
-                    .icon=${mdiAccount}
-                    .value="@${author}"
-                  ></hacs-chip>`
-                )
-              : ""}
-            ${this._repository.downloads
-              ? html` <hacs-chip
-                  title="${this.hacs.localize("dialog_info.downloads")}"
-                  .icon=${mdiArrowDownBold}
-                  .value=${this._repository.downloads}
-                ></hacs-chip>`
-              : ""}
-            <hacs-chip
-              title="${this.hacs.localize("dialog_info.stars")}"
-              .icon=${mdiStar}
-              .value=${this._repository.stars}
-            ></hacs-chip>
-            <hacs-chip
-              title="${this.hacs.localize("dialog_info.open_issues")}"
-              .icon=${mdiExclamationThick}
-              .value=${this._repository.issues}
-              .url="https://github.com/${this._repository.full_name}/issues"
-            ></hacs-chip>
-          </div>
           ${this._repository.updated_info
-            ? markdown.html(
-                this._repository.additional_info || this.hacs.localize("dialog_info.no_info"),
-                this._repository
-              )
-            : this.hacs.localize("dialog_info.loading")}
+          ? html`
+            <div class="chips">
+              ${this._repository.installed
+                ? html`<hacs-chip
+                    title="${this.hacs.localize("dialog_info.version_installed")}"
+                    .icon=${mdiCube}
+                    .value=${this._repository.installed_version}
+                  ></hacs-chip>`
+                : ""}
+              ${authors
+                ? authors.map(
+                    (author) => html`<hacs-chip
+                      title="${this.hacs.localize("dialog_info.author")}"
+                      .url="https://github.com/${author}"
+                      .icon=${mdiAccount}
+                      .value="@${author}"
+                    ></hacs-chip>`
+                  )
+                : ""}
+              ${this._repository.downloads
+                ? html` <hacs-chip
+                    title="${this.hacs.localize("dialog_info.downloads")}"
+                    .icon=${mdiArrowDownBold}
+                    .value=${this._repository.downloads}
+                  ></hacs-chip>`
+                : ""}
+              <hacs-chip
+                title="${this.hacs.localize("dialog_info.stars")}"
+                .icon=${mdiStar}
+                .value=${this._repository.stars}
+              ></hacs-chip>
+              <hacs-chip
+                title="${this.hacs.localize("dialog_info.open_issues")}"
+                .icon=${mdiExclamationThick}
+                .value=${this._repository.issues}
+                .url="https://github.com/${this._repository.full_name}/issues"
+              ></hacs-chip>
+            </div>
+            ${markdown.html(
+              this._repository.additional_info || this.hacs.localize("dialog_info.no_info"),
+              this._repository
+            )}`
+          : html`
+            <div class="loading">
+              <ha-circular-progress active size="large"></ha-circular-progress>
+            </div>
+          `}
         </div>
         ${!this._repository.installed && this._repository.updated_info
           ? html`
@@ -139,6 +144,12 @@ export class HacsRepositoryDialog extends HacsDialogBase {
         }
         img {
           max-width: 100%;
+        }
+        .loading {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 4rem 8rem;
         }
         .chips {
           display: flex;

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -225,7 +225,6 @@
     "downloads": "Downloads",
     "author": "Author",
     "no_info": "The developer has not provided any more information for this repository",
-    "loading": "Loading information...",
     "open_repo": "Open repository",
     "install": "Install this repository in HACS"
   },


### PR DESCRIPTION
Old:

![image](https://user-images.githubusercontent.com/23432278/121813839-212d0700-cc6e-11eb-9466-d174cb831b14.png)


New:

![image](https://user-images.githubusercontent.com/23432278/121813802-fb076700-cc6d-11eb-8cb5-dde7ac22f04f.png)
