### PR TITLE
Updated 'Pending restart' directions

### DIFF
--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -337,7 +337,7 @@
       },
       "restart": {
         "title": "Pending restart",
-        "content": "You have {number} {pluralWording} for which a restart of Home Assistant is required. You can do that from the 'Server Controls' section under the configuration part of Home Assistant UI."
+        "content": "You have {number} {pluralWording} for which a restart of Home Assistant is required. You can do that from the 'Server management' section under the configuration part of Home Assistant UI."
       },
       "removed": "Removed repository '{repository}'"
     },


### PR DESCRIPTION
The directions given after updating HACS integration that require a restart don't currently match the section header on the Server Controls page. This PR updates the English localization to match the current HA section header.