### PR TITLE
Fix entrypoint script tag fallback

### DIFF
--- a/script/gulp/rollup.js
+++ b/script/gulp/rollup.js
@@ -143,6 +143,7 @@ try {
 } catch (err) {
   var el = document.createElement('script');
   el.src = '/hacsfiles/frontend/${entrypointManifest["./src/main.ts"]}';
+  el.type = 'module';
   document.body.appendChild(el);
 }
   `,


### PR DESCRIPTION
Entrypoint.js  tries to load the main script using dynamic import and falls back to adding a script tag if this fails.
However, the main script is an es module so a normal script fails on the "toplevel export", as reported by https://github.com/hacs/integration/issues/1764
By setting the module attribute on the script tag the script loads successfully. 

(This is more of an band-aid fix. I assume that there is no good way to pass the main script as module js file directly? )