### PR TITLE
use mainWindow instead of top to open links

### DIFF
--- a/src/components/hacs-repository-card.ts
+++ b/src/components/hacs-repository-card.ts
@@ -33,6 +33,7 @@ import {
 import { HacsStyles } from "../styles/hacs-common-style";
 import { generateLovelaceURL } from "../tools/added-to-lovelace";
 import "./hacs-link";
+import { mainWindow } from "../../homeassistant-frontend/src/common/dom/get_main_window";
 
 @customElement("hacs-repository-card")
 export class HacsRepositoryCard extends LitElement {
@@ -133,7 +134,7 @@ export class HacsRepositoryCard extends LitElement {
                     path: mdiGithub,
                     label: this.hacs.localize("common.repository"),
                     action: () =>
-                      top?.open(
+                      mainWindow.open(
                         `https://github.com/${this.repository.full_name}`,
                         "_blank",
                         "noreferrer=true"
@@ -154,7 +155,7 @@ export class HacsRepositoryCard extends LitElement {
                     path: mdiLanguageJavascript,
                     label: this.hacs.localize("repository_card.open_source"),
                     action: () =>
-                      top?.open(
+                      mainWindow.open(
                         `/hacsfiles/${path.pop()}/${this.repository.file_name}`,
                         "_blank",
                         "noreferrer=true"
@@ -164,7 +165,7 @@ export class HacsRepositoryCard extends LitElement {
                     path: mdiAlertCircleOutline,
                     label: this.hacs.localize("repository_card.open_issue"),
                     action: () =>
-                      top?.open(
+                      mainWindow.open(
                         `https://github.com/${this.repository.full_name}/issues`,
                         "_blank",
                         "noreferrer=true"
@@ -175,7 +176,7 @@ export class HacsRepositoryCard extends LitElement {
                     path: mdiAlert,
                     label: this.hacs.localize("repository_card.report"),
                     action: () =>
-                      top?.open(
+                      mainWindow.open(
                         `https://github.com/hacs/integration/issues/new?assignees=ludeeus&labels=flag&template=removal.yml&repo=${this.repository.full_name}&title=Request for removal of ${this.repository.full_name}`,
                         "_blank",
                         "noreferrer=true"

--- a/src/panels/hacs-store-panel.ts
+++ b/src/panels/hacs-store-panel.ts
@@ -27,6 +27,7 @@ import { hassTabsSubpage, scrollBarStyle, searchStyles } from "../styles/element
 import { HacsStyles } from "../styles/hacs-common-style";
 import { filterRepositoriesByInput } from "../tools/filter-repositories-by-input";
 import { activePanel } from "./hacs-sections";
+import { mainWindow } from "../../homeassistant-frontend/src/common/dom/get_main_window";
 
 @customElement("hacs-store-panel")
 export class HacsStorePanel extends LitElement {
@@ -137,17 +138,17 @@ export class HacsStorePanel extends LitElement {
           {
             path: mdiFileDocument,
             label: this.hacs.localize("menu.documentation"),
-            action: () => top?.open("https://hacs.xyz/", "_blank", "noreferrer=true"),
+            action: () => mainWindow.open("https://hacs.xyz/", "_blank", "noreferrer=true"),
           },
           {
             path: mdiGithub,
             label: "GitHub",
-            action: () => top?.open("https://github.com/hacs", "_blank", "noreferrer=true"),
+            action: () => mainWindow.open("https://github.com/hacs", "_blank", "noreferrer=true"),
           },
           {
             path: mdiAlertCircleOutline,
             label: this.hacs.localize("menu.open_issue"),
-            action: () => top?.open("https://hacs.xyz/docs/issues", "_blank", "noreferrer=true"),
+            action: () => mainWindow.open("https://hacs.xyz/docs/issues", "_blank", "noreferrer=true"),
           },
           {
             path: mdiGit,


### PR DESCRIPTION
Fixes https://github.com/hacs/integration/issues/2351

This PR changes all uses of "top?.open" to "mainWindow.open" provided by the HA frontend. This allows the links to be opened when HA is embedded in an iFrame.
Note that the links still open in new tabs as intended and do not replace the HACS/HA/Parent content.

Tested with HA 2021.12.4, HACS 1.18.0 & Firefox 95.0.2.