### PR TITLE
Better detection of relative URLs.

### DIFF
--- a/src/tools/markdown/markdown.ts
+++ b/src/tools/markdown/markdown.ts
@@ -50,8 +50,9 @@ export class markdown {
 
     // Handle relative links
     if (repo) {
-      input = input.replace(/!\[*.*\]\(\w*\.\w*\)/g, function (x) {
+      input = input.replace(/!\[*.*\]\((?!.*:\/\/).*\/*.*\.\w*\)/g, function (x) {
         return x
+          .replace("(/", "(")
           .replace("(", `(https://raw.githubusercontent.com/${repo?.full_name}/master/`)
           .replace("/blob/", "/");
       });


### PR DESCRIPTION
Detects relative URLs that include special characters, such as those used in the images for [this repo](https://github.com/AnthonMS/my-cards). See https://regexr.com/6gft9 for examples of what is/is not picked up by the new expression.

The new expression is activated by, essentially, by the pattern `any-chars.word`. It will _not_ activate if it detects `://` in the string, as this indicates that an absolute URL is in use.