### PR TITLE
fix addon button

### DIFF
--- a/src/panels/hacs-entry-panel.ts
+++ b/src/panels/hacs-entry-panel.ts
@@ -160,7 +160,7 @@ export class HacsEntryPanel extends LitElement {
             >
             </ha-config-navigation>
 
-            ${!isComponentLoaded(this.hass, "hassio")
+            ${isComponentLoaded(this.hass, "hassio")
               ? html`
                   <div class="list-item" @click=${this._openSupervisorDialog}>
                     <div class="list-item-icon">


### PR DESCRIPTION
Only show the Addon button, when the supervisor is installed and not the other way around.
In the new version (1.24) I can see the addon button also if I don't have installed the supervisor. I only run the docker container.

Bug was introduced probably by mistake on #570

