### PR TITLE
Remove icon next to add-on entry

### DIFF
--- a/src/panels/hacs-entry-panel.ts
+++ b/src/panels/hacs-entry-panel.ts
@@ -176,9 +176,6 @@ export class HacsEntryPanel extends LitElement {
                         ${this.hacs.localize(`sections.addon.description`)}
                       </div>
                     </div>
-                    ${!this.narrow
-                      ? html`<ha-svg-icon right .path=${mdiOpenInNew}></ha-svg-icon>`
-                      : ""}
                   </div>
                 `
               : ""}
@@ -340,7 +337,7 @@ export class HacsEntryPanel extends LitElement {
         }
         .list-item-description {
           color: var(--secondary-text-color);
-          margin-right: 56px;
+          margin-right: 16px;
         }
         .list-item ha-icon-next,
         .list-item ha-svg-icon[right] {

--- a/src/panels/hacs-entry-panel.ts
+++ b/src/panels/hacs-entry-panel.ts
@@ -1,5 +1,5 @@
 import "@material/mwc-button/mwc-button";
-import { mdiAlertCircle, mdiGithub, mdiHomeAssistant, mdiInformation, mdiOpenInNew } from "@mdi/js";
+import { mdiAlertCircle, mdiGithub, mdiHomeAssistant, mdiInformation } from "@mdi/js";
 import "@polymer/app-layout/app-header/app-header";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";

--- a/src/panels/hacs-entry-panel.ts
+++ b/src/panels/hacs-entry-panel.ts
@@ -340,7 +340,7 @@ export class HacsEntryPanel extends LitElement {
         }
         .list-item-description {
           color: var(--secondary-text-color);
-          margin-right: 16px;
+          margin-right: 56px;
         }
         .list-item ha-icon-next,
         .list-item ha-svg-icon[right] {


### PR DESCRIPTION
Potentially too hacky, but I used `56px` since that is the width of the icon plus its margin on the right.

**Before:**
![image](https://user-images.githubusercontent.com/114137/161448648-c3983717-bc56-47d8-a239-2e492975d0cd.png)

**After:**
![image](https://user-images.githubusercontent.com/114137/161448631-06051a37-9b05-45ee-9dd1-f5f44d6de223.png)

Only tested via browser dev tools.