### PR TITLE
Update "restart" link to redirect to System Settings

### DIFF
--- a/src/tools/get-messages.ts
+++ b/src/tools/get-messages.ts
@@ -68,7 +68,7 @@ export const getMessages = memoizeOne((hacs: Hacs, loadedIntegrationMy: boolean)
   if (repositoriesRestartPending.length > 0) {
     messages.push({
       name: hacs.localize("entry.messages.restart.title"),
-      path: loadedIntegrationMy ? "/_my_redirect/server_controls" : undefined,
+      path: loadedIntegrationMy ? "/_my_redirect/system_dashboard" : undefined,
       info: hacs.localize("entry.messages.restart.content", {
         number: repositoriesRestartPending.length,
         pluralWording:


### PR DESCRIPTION
This updates the restart link to redirect to System Settings instead of the YAML section of Developer Tools. There is a restart button on the System Settings page.

Redirecting to the YAML section of Developer Tools may be a bit confusing for users who don't use YAML or are not familiar with the Developer Tools. System Settings seems more appropriate since it is a page that all HA users will be familiar with.