### PR TITLE
Fix restart link

### DIFF
--- a/src/tools/get-messages.ts
+++ b/src/tools/get-messages.ts
@@ -68,7 +68,7 @@ export const getMessages = memoizeOne((hacs: Hacs, loadedIntegrationMy: boolean)
   if (repositoriesRestartPending.length > 0) {
     messages.push({
       name: hacs.localize("entry.messages.restart.title"),
-      path: loadedIntegrationMy ? "/_my_redirect/server_controls" : undefined,
+      path: loadedIntegrationMy ? "/_my_redirect/system_dashboard" : undefined,
       info: hacs.localize("entry.messages.restart.content", {
         number: repositoriesRestartPending.length,
         pluralWording:


### PR DESCRIPTION
Home Assistant moved the restart button to the System Dashboard in 2022.5