### PR TITLE
Fix button alignment issue in repo preview

### DIFF
--- a/src/components/dialogs/hacs-repository-info-dialog.ts
+++ b/src/components/dialogs/hacs-repository-info-dialog.ts
@@ -168,10 +168,6 @@ export class HacsRepositoryDialog extends HacsDialogBase {
           padding-bottom: 8px;
           gap: 4px;
         }
-
-        hacs-link mwc-button {
-          margin-top: -18px;
-        }
       `,
     ];
   }


### PR DESCRIPTION
**Note**: I don't have a HACS dev setup, so only tested via browser dev tools.

The "Open Repository" button is misaligned.

![image](https://user-images.githubusercontent.com/114137/170327777-812107db-0078-477d-ad9e-86e3c912431c.png)
