### PR TITLE
Revert "Remove version selector"

### DIFF
--- a/src/data/repository.ts
+++ b/src/data/repository.ts
@@ -69,3 +69,14 @@ export const repositoryDownloadVersion = async (
     repository: repository,
     version,
   });
+
+export const repositorySetVersion = async (
+  hass: HomeAssistant,
+  repository: string,
+  version: string
+) =>
+  hass.connection.sendMessagePromise<void>({
+    type: "hacs/repository/version",
+    repository: repository,
+    version,
+  });

--- a/src/data/websocket.ts
+++ b/src/data/websocket.ts
@@ -26,6 +26,13 @@ export const repositoryAdd = async (hass: HomeAssistant, repository: string, cat
     category,
   });
 
+export const repositoryBeta = async (hass: HomeAssistant, repository: string, beta: boolean) =>
+  hass.connection.sendMessagePromise<void>({
+    type: "hacs/repository/beta",
+    repository,
+    show_beta: beta,
+  });
+
 export const repositoryUpdate = async (hass: HomeAssistant, repository: string) =>
   hass.connection.sendMessagePromise<void>({
     type: "hacs/repository/refresh",


### PR DESCRIPTION
Reverts hacs/frontend#684

While this should be removed, its replacement is still pretty new, so it is nice to have as a fallback for a little while.