### PR TITLE
Move filter/columns selectors from overflow to dialog

### DIFF
--- a/src/components/dialogs/hacs-form-dialog.ts
+++ b/src/components/dialogs/hacs-form-dialog.ts
@@ -36,7 +36,7 @@ class HacsFromDialog extends LitElement {
         console.log(data);
         this._errors = { base: data?.message || data };
       },
-      HacsDispatchEvent.ERROR
+      HacsDispatchEvent.ERROR,
     );
     await this.updateComplete;
   }
@@ -126,17 +126,15 @@ class HacsFromDialog extends LitElement {
   }
 
   private _computeLabel = (schema: HaFormSchema, data: HaFormDataContainer) =>
-    this._dialogParams!.computeLabelCallback
-      ? this._dialogParams!.computeLabelCallback(schema, data)
+    this._dialogParams?.computeLabelCallback
+      ? this._dialogParams.computeLabelCallback(schema, data)
       : schema.name || "";
 
   private _computeHelper = (schema: HaFormSchema) =>
-    this._dialogParams!.computeHelper ? this._dialogParams!.computeHelper(schema) : "";
+    this._dialogParams?.computeHelper ? this._dialogParams.computeHelper(schema) : "";
 
   private _computeError = (error, schema: HaFormSchema | readonly HaFormSchema[]) =>
-    this._dialogParams!.computeError
-      ? this._dialogParams!.computeError(error, schema)
-      : error || "";
+    this._dialogParams?.computeError ? this._dialogParams.computeError(error, schema) : error || "";
 
   static get styles(): CSSResultGroup {
     return css`

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -56,6 +56,17 @@
     "downloaded_repositories": "Downloaded repositories",
     "useful_links": "Useful links"
   },
+  "dialog_overview": {
+    "title": "Manage overview table",
+    "description": "Change what is shown in the overview table to match your needs.",
+    "sections": {
+      "filters": "Change active filters",
+      "behaviour": "Change the behaviour of the overview"
+    },
+    "base": "Base filters",
+    "category": "Category",
+    "columns": "Columns"
+  },
   "dialog_add_repo": {
     "title": "Add repository",
     "no_match": "No repositories found matching your filter",


### PR DESCRIPTION
As there is an issue with checkboxes in overflow menus, this is moving to a dialog instead, which also makes it easier to extend in the future.

<img width="603" alt="2024-01-13_11-03-45" src="https://github.com/hacs/frontend/assets/15093472/18d3199c-5908-4573-bc7d-e6e56e489f60">
