### PR TITLE
Fix `dialog_update.message` English translation

### DIFF
--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -110,7 +110,7 @@
     "available_version": "Available version",
     "changelog": "Changelog",
     "releasenotes": "Release notes for {release}",
-    "message": "A new version of the {name} is available",
+    "message": "A new version of {name} is available",
     "no_info": "The author has not provided any information for this release"
   },
   "dialog_browse": {


### PR DESCRIPTION
The current message for this key is a bit awkward and has a stray article.