### PR TITLE
Forward `a`, `d` and `m` keyboard shortcuts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,7 @@ class HacsFrontend extends HacsElement {
         // Ignore if modifier keys are pressed
         return;
       }
-      if (["c", "e"].includes(ev.key)) {
+      if (["a", "c", "d", "e", "m"].includes(ev.key)) {
         // @ts-ignore
         fireEvent(mainWindow, "hass-quick-bar-trigger", ev, {
           bubbles: false,


### PR DESCRIPTION
`m` will only show a toast that the link can't be found, but imho better than users expecting it to work waiting for some action.