### PR TITLE
Link stars chip to GitHub stargazers page

### DIFF
--- a/src/dashboards/hacs-repository-dashboard.ts
+++ b/src/dashboards/hacs-repository-dashboard.ts
@@ -239,13 +239,19 @@ export class HacsRepositoryDashboard extends LitElement {
                     <ha-svg-icon slot="icon" .path=${mdiArrowDownBold}></ha-svg-icon>
                   </ha-assist-chip>`
                 : ""}
-              <ha-assist-chip
-                .label=${String(this._repository.stars)}
-                title="${this.hacs.localize("dialog_info.stars")}"
+              <a
+                href="https://github.com/${this._repository.full_name}/stargazers"
+                target="_blank"
+                rel="noreferrer noopener"
               >
-                <ha-svg-icon slot="icon" .path=${mdiStar}></ha-svg-icon>
-                ${this._repository.stars}
-              </ha-assist-chip>
+                <ha-assist-chip
+                  .label=${String(this._repository.stars)}
+                  title="${this.hacs.localize("dialog_info.stars")}"
+                >
+                  <ha-svg-icon slot="icon" .path=${mdiStar}></ha-svg-icon>
+                  ${this._repository.stars}
+                </ha-assist-chip>
+              </a>
               <a
                 href="https://github.com/${this._repository.full_name}/issues"
                 target="_blank"


### PR DESCRIPTION
The stars count chip on the repository dashboard looks clickable but doesn't actually navigate anywhere. This wraps it in an anchor tag linking to the GitHub stargazers page, matching the pattern already used by the issues chip right next to it.