### PR TITLE
Use brandsUrl for dashboard brand icons and keep HACS fallback

### DIFF
--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -39,7 +39,6 @@ import "../../homeassistant-frontend/src/components/ha-svg-icon";
 import { PageNavigation } from "../../homeassistant-frontend/src/layouts/hass-tabs-subpage";
 import { haStyle } from "../../homeassistant-frontend/src/resources/styles";
 import type { HomeAssistant, Route } from "../../homeassistant-frontend/src/types";
-import { brandsUrl } from "../../homeassistant-frontend/src/util/brands-url";
 import {
   showHacsCustomRepositoriesDialog,
   showHacsFormDialog,
@@ -63,6 +62,14 @@ const defaultKeyData = {
 };
 
 const STATUS_ORDER = ["pending-restart", "pending-upgrade", "installed", "new", "default"];
+
+const repositoryHostedBrandIconUrl = (repository: RepositoryBase, dark: boolean): string =>
+  repository.domain
+    ? `https://brands.home-assistant.io/${repository.domain}/${dark ? "dark_icon.png" : "icon.png"}`
+    : repositoryFallbackIconUrl(repository, dark);
+
+const repositoryFallbackIconUrl = (repository: RepositoryBase, dark: boolean): string =>
+  `/api/hacs/icon/${repository.id}${dark ? "?dark=1" : ""}`;
 
 const TABS: PageNavigation[] = [
   {
@@ -113,6 +120,15 @@ export class HacsDashboard extends LitElement {
 
   @state()
   private _overflowMenuRepository?: RepositoryBase;
+
+  private _handleRepositoryIconError(ev: Event, repository: RepositoryBase): void {
+    const img = ev.currentTarget as HTMLImageElement;
+    const fallback = repositoryFallbackIconUrl(repository, Boolean(this.hass.themes?.darkMode));
+    if (img.src.endsWith(fallback)) {
+      return;
+    }
+    img.src = fallback;
+  }
 
   protected render = (): TemplateResult | void => {
     const repositories = this._filterRepositories(
@@ -327,12 +343,11 @@ export class HacsDashboard extends LitElement {
                 <img
                   style="height: 32px; width: 32px"
                   slot="item-icon"
-                  src=${brandsUrl({
-                    domain: repository.domain || "invalid",
-                    type: "icon",
-                    useFallback: true,
-                    darkOptimized: this.hass.themes?.darkMode,
-                  })}
+                  src=${repositoryHostedBrandIconUrl(
+                    repository,
+                    Boolean(this.hass.themes?.darkMode),
+                  )}
+                  @error=${(ev: Event) => this._handleRepositoryIconError(ev, repository)}
                   referrerpolicy="no-referrer"
                 />
               `

--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -39,6 +39,7 @@ import "../../homeassistant-frontend/src/components/ha-svg-icon";
 import { PageNavigation } from "../../homeassistant-frontend/src/layouts/hass-tabs-subpage";
 import { haStyle } from "../../homeassistant-frontend/src/resources/styles";
 import type { HomeAssistant, Route } from "../../homeassistant-frontend/src/types";
+import { brandsUrl } from "../../homeassistant-frontend/src/util/brands-url";
 import {
   showHacsCustomRepositoriesDialog,
   showHacsFormDialog,
@@ -65,7 +66,11 @@ const STATUS_ORDER = ["pending-restart", "pending-upgrade", "installed", "new", 
 
 const repositoryHostedBrandIconUrl = (repository: RepositoryBase, dark: boolean): string =>
   repository.domain
-    ? `https://brands.home-assistant.io/${repository.domain}/${dark ? "dark_icon.png" : "icon.png"}`
+    ? brandsUrl({
+        domain: repository.domain,
+        type: "icon",
+        darkOptimized: dark,
+      })
     : repositoryFallbackIconUrl(repository, dark);
 
 const repositoryFallbackIconUrl = (repository: RepositoryBase, dark: boolean): string =>


### PR DESCRIPTION
## Summary

- prefer Home Assistant's shared `brandsUrl(...)` helper for the primary dashboard brand icon URL
- keep the dashboard image fallback to `/api/hacs/icon/{repository_id}` when the hosted brand asset is missing
- avoid hardcoding the hosted `brands.home-assistant.io` URL pattern in HACS frontend code

## Details

This keeps the dashboard rendering change in `hacs/frontend`, not in `hacs/integration`.

The dashboard now builds the primary hosted icon URL through Home Assistant's existing `brandsUrl(...)` helper and still falls back in the browser to the HACS endpoint when the hosted asset is missing.

That keeps the frontend aligned with Home Assistant's own brand URL utility while preserving the existing fallback behavior expected by the companion integration change.

## Testing

- `npx -y node@18 ./node_modules/gulp-cli/bin/gulp.js build-hacs`