### PR TITLE
Prefer local brand icons for installed integrations

### DIFF
--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -309,6 +309,38 @@ export class HacsDashboard extends LitElement {
         })),
   );
 
+  private _repositoryBrandFallbackUrl(repository: RepositoryBase): string {
+    return brandsUrl({
+      domain: repository.domain || "invalid",
+      type: "icon",
+      useFallback: true,
+      darkOptimized: this.hass.themes?.darkMode,
+    });
+  }
+
+  private _repositoryBrandUrl(repository: RepositoryBase): string {
+    if (!repository.installed || !repository.domain) {
+      return this._repositoryBrandFallbackUrl(repository);
+    }
+
+    return `/api/brands/integration/${repository.domain}/icon.png`;
+  }
+
+  private _handleRepositoryBrandError = (event: Event): void => {
+    const image = event.currentTarget;
+    if (!(image instanceof HTMLImageElement)) {
+      return;
+    }
+
+    const fallbackSrc = image.dataset.fallbackSrc;
+    if (!fallbackSrc || image.getAttribute("src") === fallbackSrc) {
+      return;
+    }
+
+    image.src = fallbackSrc;
+    image.removeAttribute("data-fallback-src");
+  };
+
   private _columns = memoize(
     (
       localizeFunc: LocalizeFunc<HacsLocalizeKeys>,
@@ -327,12 +359,9 @@ export class HacsDashboard extends LitElement {
                 <img
                   style="height: 32px; width: 32px"
                   slot="item-icon"
-                  src=${brandsUrl({
-                    domain: repository.domain || "invalid",
-                    type: "icon",
-                    useFallback: true,
-                    darkOptimized: this.hass.themes?.darkMode,
-                  })}
+                  src=${this._repositoryBrandUrl(repository)}
+                  data-fallback-src=${this._repositoryBrandFallbackUrl(repository)}
+                  @error=${this._handleRepositoryBrandError}
                   referrerpolicy="no-referrer"
                 />
               `


### PR DESCRIPTION
## Summary
- prefer the local Home Assistant Brands Proxy icon for installed custom integrations
- keep the existing CDN-based randsUrl() path as a fallback when the local icon is unavailable
- limit the change to installed integrations so non-installed repositories continue using the existing behavior

## Why
Home Assistant 2026.3+ can serve brand assets for installed custom integrations via /api/brands/integration/<domain>/icon.png, but the HACS repository list still renders icons via the CDN-based randsUrl() helper. That means integrations with local brand assets can still show the placeholder icon in HACS even though Home Assistant itself displays the correct icon.

This change makes the HACS dashboard prefer the local brand icon for installed integrations and gracefully fall back to the existing CDN path if the local asset is not available.

Refs hacs/integration#5179

## Testing
- not run locally; this environment does not have Node/Yarn available
- verified the affected render path manually in src/dashboards/hacs-dashboard.ts
