### PR TITLE
Add topics

### DIFF
--- a/src/components/hacs-data-table-topics.ts
+++ b/src/components/hacs-data-table-topics.ts
@@ -1,0 +1,100 @@
+import type { TemplateResult } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import { repeat } from "lit/directives/repeat";
+
+import "../../homeassistant-frontend/src/components/chips/ha-chip-set";
+import "../../homeassistant-frontend/src/components/ha-button-menu";
+import "../../homeassistant-frontend/src/components/ha-label";
+import "../../homeassistant-frontend/src/components/ha-list-item";
+
+const MAX_VISIBLE_TOPICS = 2;
+
+@customElement("hacs-data-table-topics")
+export class HacsDataTableTopics extends LitElement {
+  @property({ attribute: false }) public topics: string[] = [];
+
+  protected render(): TemplateResult {
+    if (!this.topics.length) {
+      return nothing;
+    }
+
+    return html`
+      <ha-chip-set>
+        ${repeat(
+          this.topics.slice(0, MAX_VISIBLE_TOPICS),
+          (topic) => topic,
+          (topic) => html`<ha-label dense>${topic}</ha-label>`,
+        )}
+        ${this.topics.length > MAX_VISIBLE_TOPICS
+          ? html`<ha-button-menu
+              absolute
+              role="button"
+              tabindex="0"
+              @click=${this._handleOverflowMenuOpened}
+              @closed=${this._handleOverflowMenuClosed}
+            >
+              <ha-label slot="trigger" class="plus" dense>
+                +${this.topics.length - MAX_VISIBLE_TOPICS}
+              </ha-label>
+              ${repeat(
+                this.topics.slice(MAX_VISIBLE_TOPICS),
+                (topic) => topic,
+                (topic) => html`
+                  <ha-list-item noninteractive>
+                    <ha-label dense>${topic}</ha-label>
+                  </ha-list-item>
+                `,
+              )}
+            </ha-button-menu>`
+          : nothing}
+      </ha-chip-set>
+    `;
+  }
+
+  protected _handleOverflowMenuOpened(e) {
+    e.stopPropagation();
+    const row = this.closest(".mdc-data-table__row") as HTMLDivElement | null;
+    if (row) {
+      row.style.zIndex = "1";
+    }
+  }
+
+  protected _handleOverflowMenuClosed() {
+    const row = this.closest(".mdc-data-table__row") as HTMLDivElement | null;
+    if (row) {
+      row.style.zIndex = "";
+    }
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+        flex-grow: 1;
+        margin-top: 4px;
+        height: 22px;
+      }
+
+      ha-chip-set {
+        position: fixed;
+        flex-wrap: nowrap;
+      }
+
+      ha-button-menu {
+        border-radius: 10px;
+      }
+
+      .plus {
+        --ha-label-background-color: transparent;
+        border: 1px solid var(--divider-color);
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hacs-data-table-topics": HacsDataTableTopics;
+  }
+}

--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -421,7 +421,13 @@ export class HacsDashboard extends LitElement {
       domain: defaultKeyData,
       full_name: defaultKeyData,
       id: defaultKeyData,
-      topics: defaultKeyData,
+      topics: {
+        ...defaultKeyData,
+        title: localizeFunc("column.topics"),
+        hidden: false,
+        template: (repository: RepositoryBase) =>
+          repository.topics?.length ? repository.topics.join(", ") : "-",
+      },
       actions: {
         title: "",
         label: localizeFunc("column.actions"),

--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -55,6 +55,7 @@ import { HacsStyles } from "../styles/hacs-common-style";
 import { documentationUrl } from "../tools/documentation";
 import { typeIcon } from "../tools/type-icon";
 import { showAlertDialog } from "../../homeassistant-frontend/src/dialogs/generic/show-dialog-box";
+import "../components/hacs-data-table-topics";
 
 const defaultKeyData = {
   title: "",
@@ -425,8 +426,11 @@ export class HacsDashboard extends LitElement {
         ...defaultKeyData,
         title: localizeFunc("column.topics"),
         hidden: false,
+        defaultHidden: true,
         template: (repository: RepositoryBase) =>
-          repository.topics?.length ? repository.topics.join(", ") : "-",
+          repository.topics?.length
+            ? html`<hacs-data-table-topics .topics=${repository.topics}></hacs-data-table-topics>`
+            : "-",
       },
       actions: {
         title: "",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -35,6 +35,7 @@
     "available_version": "Available version",
     "status": "Status",
     "type": "Type",
+    "topics": "Topics",
     "last_updated": "Activity"
   },
   "confirm": {


### PR DESCRIPTION
> [!NOTE]
> Frontend submodule probably needs an update, I tested this with the latest ha prod build on `hacs/integration` (newer frontend than submodule) 

Part of an attempt to make visibility of community dashboards, cards etc. by using topics as a stopgap. This requires the maintainer to add topics, it's not a full "subtype" implementation but it may help somewhat

Discussion that started this: https://discord.com/channels/330944238910963714/1351536906437005313/1493961071852257415

Topics column to table (not sure if this is always wanted so hidden by default):

<img width="2826" height="1761" alt="image" src="https://github.com/user-attachments/assets/792c41bf-5f39-4809-adcf-02d9c0795560" />

Filtering by topic:

Thought about doing this, but after seeing the amount of topics, it doesnt really make sense without a proper virtualized generic picker with search