### PR TITLE
Use authenticated brands proxy for repository icons

### DIFF
--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -10,7 +10,7 @@ import {
   mdiInformation,
   mdiNewBox,
 } from "@mdi/js";
-import type { CSSResultGroup, TemplateResult } from "lit";
+import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import memoize from "memoize-one";
@@ -39,7 +39,11 @@ import "../../homeassistant-frontend/src/components/ha-svg-icon";
 import { PageNavigation } from "../../homeassistant-frontend/src/layouts/hass-tabs-subpage";
 import { haStyle } from "../../homeassistant-frontend/src/resources/styles";
 import type { HomeAssistant, Route } from "../../homeassistant-frontend/src/types";
-import { brandsUrl } from "../../homeassistant-frontend/src/util/brands-url";
+import {
+  brandsUrl,
+  clearBrandsTokenRefresh,
+  fetchAndScheduleBrandsAccessToken,
+} from "../../homeassistant-frontend/src/util/brands-url";
 import {
   showHacsCustomRepositoriesDialog,
   showHacsFormDialog,
@@ -113,6 +117,16 @@ export class HacsDashboard extends LitElement {
 
   @state()
   private _overflowMenuRepository?: RepositoryBase;
+
+  protected firstUpdated(changedProps: PropertyValues): void {
+    super.firstUpdated(changedProps);
+    fetchAndScheduleBrandsAccessToken(this.hass);
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    clearBrandsTokenRefresh();
+  }
 
   protected render = (): TemplateResult | void => {
     const repositories = this._filterRepositories(
@@ -330,7 +344,6 @@ export class HacsDashboard extends LitElement {
                   src=${brandsUrl({
                     domain: repository.domain || "invalid",
                     type: "icon",
-                    useFallback: true,
                     darkOptimized: this.hass.themes?.darkMode,
                   })}
                   referrerpolicy="no-referrer"


### PR DESCRIPTION
## Summary

The HACS dashboard shows "icon not available" for custom integrations that ship inline brand assets (a feature introduced in Home Assistant 2026.3). Root cause is a combination of three things:

- The `homeassistant-frontend` submodule is pinned to `3ffbd435` (2025-01-09) — pre-brands-proxy.
- At that revision, `brandsUrl({...})` still returns `https://brands.home-assistant.io/_/{domain}/icon.png`. That CDN no longer accepts new custom-integration submissions (see the [brands-proxy API blog post](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api/)), so custom-integration icons 404.
- The dashboard passes `useFallback: true` — a parameter that has since been removed from upstream `BrandsOptions`, so a naive submodule bump breaks the TypeScript compile.

### Changes

1. **Bump `homeassistant-frontend` submodule** to current upstream `master` — brings in the new `brands-url.ts` that returns `/api/brands/integration/{domain}/icon.png?token=…`, along with `fetchAndScheduleBrandsAccessToken` / `clearBrandsTokenRefresh` exports.
2. **Remove `useFallback: true`** from the `brandsUrl({...})` call in `src/dashboards/hacs-dashboard.ts` — the field no longer exists on `BrandsOptions`. Fallback is now the HA backend's job (stale-while-revalidate through the proxy).
3. **Fetch and schedule the brands access token** from the dashboard's bundle. Module-level `_brandsAccessToken` in `brands-url.ts` is bundle-scoped, so HACS must populate its own copy; upstream's `fetchAndScheduleBrandsAccessToken` silently swallows failures on older HA backends. Clear the refresh interval in `disconnectedCallback` to avoid leaking the `setInterval` when the panel unmounts.

Fixes hacs/integration#5171
Fixes hacs/integration#5223

A companion PR in the integration repo (hacs/integration) updates the HACS Update entity's `entity_picture` to use the same authenticated proxy path.

## Test plan

- [x] `script/bootstrap && script/build` compiles clean (CI via `.github/workflows/test.yml`).
- [x] Against HA ≥ 2026.3 with HACS + a custom integration shipping `brand/icon.png` inline: downloads table shows real icons; rendered `<img>` has `src=/api/brands/integration/{domain}/icon.png?token=…`.
- [x] Dark-mode toggle still flows through `darkOptimized` (filename prefixed with `dark_`).
- [x] Against HA < 2026.3 (no `brands/access_token` WS command): dashboard renders without thrown errors — `fetchAndScheduleBrandsAccessToken` catches silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)