### PR TITLE
Skip tsparticles deps that break yarn resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,8 +207,6 @@
     "stacktrace-js": "2.0.2",
     "superstruct": "2.0.2",
     "tinykeys": "3.0.0",
-    "tsparticles-engine": "2.12.0",
-    "tsparticles-preset-links": "2.12.0",
     "ua-parser-js": "1.0.40",
     "vis-data": "7.1.9",
     "vis-network": "9.1.9",
@@ -226,6 +224,10 @@
   "resolutionsOverride": {},
   "dependenciesOverride": {},
   "devDependenciesOverride": {},
+  "dependenciesIgnore": [
+    "tsparticles-engine",
+    "tsparticles-preset-links"
+  ],
   "packageManager": "yarn@4.5.3",
   "resolutions": {
     "@polymer/polymer": "patch:@polymer/polymer@3.5.2#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch",

--- a/script/merge_requirements.js
+++ b/script/merge_requirements.js
@@ -61,6 +61,11 @@ const replacePatches = (deps) =>
     ]),
   );
 
+const omitKeys = (obj, keys) =>
+  Object.fromEntries(Object.entries(obj).filter(([key]) => !keys.includes(key)));
+
+const dependenciesIgnore = hacs.dependenciesIgnore ?? [];
+
 fs.writeFileSync(
   "./package.json",
   JSON.stringify(
@@ -70,10 +75,13 @@ fs.writeFileSync(
         ...replacePatches(core.resolutions),
         ...hacs.resolutionsOverride,
       },
-      dependencies: {
-        ...replacePatches(core.dependencies),
-        ...hacs.dependenciesOverride,
-      },
+      dependencies: omitKeys(
+        {
+          ...replacePatches(core.dependencies),
+          ...hacs.dependenciesOverride,
+        },
+        dependenciesIgnore,
+      ),
       devDependencies: {
         ...replacePatches(core.devDependencies),
         ...hacs.devDependenciesOverride,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11894,8 +11894,6 @@ __metadata:
     terser-webpack-plugin: "npm:5.3.11"
     tinykeys: "npm:3.0.0"
     ts-lit-plugin: "npm:2.0.2"
-    tsparticles-engine: "npm:2.12.0"
-    tsparticles-preset-links: "npm:2.12.0"
     typescript: "npm:5.7.2"
     ua-parser-js: "npm:1.0.40"
     vis-data: "npm:7.1.9"
@@ -17788,102 +17786,6 @@ __metadata:
   version: 2.5.3
   resolution: "tslib@npm:2.5.3"
   checksum: 10/d507e60ebe2480af4efc1655dfdb2762bb6ca57d76c4ba680375af801493648c2e97808bbd7e54691eb40e33a7e2e793cdef9c24ce6a8539b03cac8b26e09a61
-  languageName: node
-  linkType: hard
-
-"tsparticles-basic@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-basic@npm:2.12.0"
-  dependencies:
-    tsparticles-engine: "npm:^2.12.0"
-    tsparticles-move-base: "npm:^2.12.0"
-    tsparticles-shape-circle: "npm:^2.12.0"
-    tsparticles-updater-color: "npm:^2.12.0"
-    tsparticles-updater-opacity: "npm:^2.12.0"
-    tsparticles-updater-out-modes: "npm:^2.12.0"
-    tsparticles-updater-size: "npm:^2.12.0"
-  checksum: 10/f1d2361d0955896f9a84e0bf2d55ac6d37a9a837ffc29bdbd07236fdd53a0d858cf16229d48716bf38449b06124f1460e85cd7185d6338e4d59dd5365075f1e0
-  languageName: node
-  linkType: hard
-
-"tsparticles-engine@npm:2.12.0, tsparticles-engine@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-engine@npm:2.12.0"
-  checksum: 10/c991f1cf7c249722d88fd5f512b36e52a8e77dc87001a074c890257d5e72caab2b1ba4ae2023f9dab6da619fe9401ea9b1326330475f0a4c0989187937b355e4
-  languageName: node
-  linkType: hard
-
-"tsparticles-interaction-particles-links@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-interaction-particles-links@npm:2.12.0"
-  dependencies:
-    tsparticles-engine: "npm:^2.12.0"
-  checksum: 10/41fed39fb8188f70a675ed81c66a38bb00100cc00bcf854d3030157ed9409ca3b5fd237a5c7d4ef3aff3c402d889e2b8b613b36fa6b2d72f857f062e02d40315
-  languageName: node
-  linkType: hard
-
-"tsparticles-move-base@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-move-base@npm:2.12.0"
-  dependencies:
-    tsparticles-engine: "npm:^2.12.0"
-  checksum: 10/4d63c17a1851057fb70445a5247164e2a6372c47504a894dc97898a25cf45b1dc3e5c1be94bc18be7410adf2fa78bb58f3cd8ebae1828abd426192043955f22d
-  languageName: node
-  linkType: hard
-
-"tsparticles-preset-links@npm:2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-preset-links@npm:2.12.0"
-  dependencies:
-    tsparticles-basic: "npm:^2.12.0"
-    tsparticles-engine: "npm:^2.12.0"
-    tsparticles-interaction-particles-links: "npm:^2.12.0"
-  checksum: 10/d64e5b4b3562fb8f037f975ed1d0a14ce41f41e9593bd3816773e26d0811317c8be26f915af25d74fa1ad5f0b5b93ebdb4d78888869f0cc2e0cf97effb25b4a7
-  languageName: node
-  linkType: hard
-
-"tsparticles-shape-circle@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-shape-circle@npm:2.12.0"
-  dependencies:
-    tsparticles-engine: "npm:^2.12.0"
-  checksum: 10/dcdd004b8e12cc56b1ee675829fa201a96e407e692064be5747490d1493e0d4a03382788e46b9f5ed9db870ae417747cde8399af616fb772742779dfd23c73c7
-  languageName: node
-  linkType: hard
-
-"tsparticles-updater-color@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-updater-color@npm:2.12.0"
-  dependencies:
-    tsparticles-engine: "npm:^2.12.0"
-  checksum: 10/572f5c4049f53fec5d375aa9da18e8162bf2e6da042e70766a09efa85ba48e63ecf47f394fb4271e7929650f137abc3ccdc6788e954722cf4a597a521a5c2bb7
-  languageName: node
-  linkType: hard
-
-"tsparticles-updater-opacity@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-updater-opacity@npm:2.12.0"
-  dependencies:
-    tsparticles-engine: "npm:^2.12.0"
-  checksum: 10/a0ef95d6bd00535380ede349d5193428279644101e7657f127a47fbed340535941d820341213c9b06acd67c6a2d0cef924319eb1001204a5b903ab1f914648b4
-  languageName: node
-  linkType: hard
-
-"tsparticles-updater-out-modes@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-updater-out-modes@npm:2.12.0"
-  dependencies:
-    tsparticles-engine: "npm:^2.12.0"
-  checksum: 10/453615fde0d54249a82f0aa15b0cd37038cb430620d48c19856d3ff724dc6f8001dabeaf820640a09fb9c27c25f2b27351b53fad33d6db3796020a49c9a33cfa
-  languageName: node
-  linkType: hard
-
-"tsparticles-updater-size@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "tsparticles-updater-size@npm:2.12.0"
-  dependencies:
-    tsparticles-engine: "npm:^2.12.0"
-  checksum: 10/47dcd8fe251db43791ee75c5cbfce9af343acc4c2a8b3a41918bbdc9af70be759b92993b79e57c5a5e35f8a85633acac1807675c8a520d9ead513ce55c3dd4dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The pinned homeassistant-frontend submodule still lists tsparticles-engine and tsparticles-preset-links in its dependencies, so script/bootstrap has been failing for every PR since.

Neither package is imported anywhere in this repo. Add a dependenciesIgnore array (mirroring the existing *Override pattern) that merge_requirements.js uses to strip listed keys from the merged dependencies before writing package.json, and regenerate yarn.lock.