### PR TITLE
Use the HACS repository icon endpoint for dashboard icons

### DIFF
--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -327,12 +327,16 @@ export class HacsDashboard extends LitElement {
                 <img
                   style="height: 32px; width: 32px"
                   slot="item-icon"
-                  src=${brandsUrl({
-                    domain: repository.domain || "invalid",
-                    type: "icon",
-                    useFallback: true,
-                    darkOptimized: this.hass.themes?.darkMode,
-                  })}
+                  src=${repository.domain
+                    ? `/api/hacs/repository/${repository.id}/${
+                        this.hass.themes?.darkMode ? "dark_icon" : "icon"
+                      }.png`
+                    : brandsUrl({
+                        domain: "invalid",
+                        type: "icon",
+                        useFallback: true,
+                        darkOptimized: this.hass.themes?.darkMode,
+                      })}
                   referrerpolicy="no-referrer"
                 />
               `

--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -327,8 +327,9 @@ export class HacsDashboard extends LitElement {
                 <img
                   style="height: 32px; width: 32px"
                   slot="item-icon"
+                  alt=""
                   src=${repository.domain
-                    ? `/api/hacs/repository/${repository.id}/${
+                    ? `/api/hacs/repository/${encodeURIComponent(repository.id)}/${
                         this.hass.themes?.darkMode ? "dark_icon" : "icon"
                       }.png`
                     : brandsUrl({

--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -10,7 +10,7 @@ import {
   mdiInformation,
   mdiNewBox,
 } from "@mdi/js";
-import type { CSSResultGroup, TemplateResult } from "lit";
+import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import memoize from "memoize-one";
@@ -63,6 +63,7 @@ const defaultKeyData = {
 };
 
 const STATUS_ORDER = ["pending-restart", "pending-upgrade", "installed", "new", "default"];
+const BRANDS_TOKEN_REFRESH_INTERVAL = 30 * 60 * 1000;
 
 const TABS: PageNavigation[] = [
   {
@@ -113,6 +114,28 @@ export class HacsDashboard extends LitElement {
 
   @state()
   private _overflowMenuRepository?: RepositoryBase;
+
+  @state()
+  private _brandsAccessToken?: string;
+
+  private _brandsTokenRefreshInterval?: number;
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    if (this.hasUpdated) {
+      this._startBrandsTokenRefresh();
+    }
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._stopBrandsTokenRefresh();
+  }
+
+  protected firstUpdated(changedProperties: PropertyValues): void {
+    super.firstUpdated(changedProperties);
+    this._startBrandsTokenRefresh();
+  }
 
   protected render = (): TemplateResult | void => {
     const repositories = this._filterRepositories(
@@ -328,17 +351,19 @@ export class HacsDashboard extends LitElement {
                   style="height: 32px; width: 32px"
                   slot="item-icon"
                   alt=""
-                  src=${repository.domain
+                  src=${repository.domain && this._brandsAccessToken
                     ? `/api/hacs/repository/${encodeURIComponent(repository.id)}/${
                         this.hass.themes?.darkMode ? "dark_icon" : "icon"
-                      }.png`
+                      }.png?token=${encodeURIComponent(this._brandsAccessToken)}`
                     : brandsUrl({
-                        domain: "invalid",
+                        domain: repository.domain || "invalid",
                         type: "icon",
                         useFallback: true,
                         darkOptimized: this.hass.themes?.darkMode,
                       })}
                   referrerpolicy="no-referrer"
+                  @error=${(event: Event) =>
+                    this._handleRepositoryIconError(event, repository.domain)}
                 />
               `
             : html`
@@ -584,6 +609,46 @@ export class HacsDashboard extends LitElement {
 
   private _handleClearFilter() {
     this._activeFilters = undefined;
+  }
+
+  private _startBrandsTokenRefresh(): void {
+    this._stopBrandsTokenRefresh();
+    void this._fetchBrandsAccessToken();
+    this._brandsTokenRefreshInterval = window.setInterval(
+      () => void this._fetchBrandsAccessToken(),
+      BRANDS_TOKEN_REFRESH_INTERVAL,
+    );
+  }
+
+  private _stopBrandsTokenRefresh(): void {
+    if (this._brandsTokenRefreshInterval !== undefined) {
+      window.clearInterval(this._brandsTokenRefreshInterval);
+      this._brandsTokenRefreshInterval = undefined;
+    }
+  }
+
+  private async _fetchBrandsAccessToken(): Promise<void> {
+    try {
+      const { token } = await this.hass.callWS<{ token: string }>({
+        type: "brands/access_token",
+      });
+      this._brandsAccessToken = token;
+    } catch {
+      this._brandsAccessToken = undefined;
+    }
+  }
+
+  private _handleRepositoryIconError(event: Event, domain?: string): void {
+    const image = event.currentTarget as HTMLImageElement;
+    const fallback = brandsUrl({
+      domain: domain || "invalid",
+      type: "icon",
+      useFallback: true,
+      darkOptimized: this.hass.themes?.darkMode,
+    });
+    if (image.src !== fallback) {
+      image.src = fallback;
+    }
   }
 
   static get styles(): CSSResultGroup {

--- a/src/dashboards/hacs-dashboard.ts
+++ b/src/dashboards/hacs-dashboard.ts
@@ -147,7 +147,12 @@ export class HacsDashboard extends LitElement {
 
     return html`<hass-tabs-subpage-data-table
         .tabs=${TABS}
-        .columns=${this._columns(this.hacs.localize, this.narrow)}
+        .columns=${this._columns(
+          this.hacs.localize,
+          this.narrow,
+          this._brandsAccessToken,
+          this.hass.themes?.darkMode,
+        )}
         .data=${repositories}
         .hass=${this.hass}
         ?iswide=${this.isWide}
@@ -336,6 +341,8 @@ export class HacsDashboard extends LitElement {
     (
       localizeFunc: LocalizeFunc<HacsLocalizeKeys>,
       narrow: boolean,
+      brandsAccessToken: string | undefined,
+      darkMode: boolean | undefined,
     ): DataTableColumnContainer<RepositoryBase> => ({
       icon: {
         title: "",
@@ -351,15 +358,15 @@ export class HacsDashboard extends LitElement {
                   style="height: 32px; width: 32px"
                   slot="item-icon"
                   alt=""
-                  src=${repository.domain && this._brandsAccessToken
+                  src=${repository.domain && brandsAccessToken
                     ? `/api/hacs/repository/${encodeURIComponent(repository.id)}/${
-                        this.hass.themes?.darkMode ? "dark_icon" : "icon"
-                      }.png?token=${encodeURIComponent(this._brandsAccessToken)}`
+                        darkMode ? "dark_icon" : "icon"
+                      }.png?token=${encodeURIComponent(brandsAccessToken)}`
                     : brandsUrl({
                         domain: repository.domain || "invalid",
                         type: "icon",
                         useFallback: true,
-                        darkOptimized: this.hass.themes?.darkMode,
+                        darkOptimized: darkMode,
                       })}
                   referrerpolicy="no-referrer"
                   @error=${(event: Event) =>
@@ -634,11 +641,12 @@ export class HacsDashboard extends LitElement {
       });
       this._brandsAccessToken = token;
     } catch {
-      this._brandsAccessToken = undefined;
+      // Keep the previous token; it usually remains valid across a transient
+      // failure, and an expired one falls back via the image error handler.
     }
   }
 
-  private _handleRepositoryIconError(event: Event, domain?: string): void {
+  private _handleRepositoryIconError(event: Event, domain?: string | null): void {
     const image = event.currentTarget as HTMLImageElement;
     const fallback = brandsUrl({
       domain: domain || "invalid",


### PR DESCRIPTION
## Proposed change

Uses the repository icon endpoint provided by hacs/integration#5388 for integration rows instead of relying only on the public brands CDN.

Since Home Assistant 2026.3, custom integrations ship brand icons inside the repository (`custom_components/<domain>/brand/`), and `home-assistant/brands` no longer accepts images for custom integrations. The CDN URLs used today therefore show placeholders for integrations that are not grandfathered in.

This change:

- obtains Home Assistant's rotating brands access token through `brands/access_token` and refreshes it every 30 minutes;
- includes the token in same-origin HACS icon URLs and keeps `referrerpolicy="no-referrer"`;
- uses `dark_icon.png` in dark mode and `icon.png` otherwise;
- falls back to the existing brands CDN URL if the token command is unavailable (for older Home Assistant versions), the repository has no domain, or the HACS endpoint fails to load;
- keeps the icon decorative with `alt=""`.

Requires hacs/integration#5388.

### Release follow-up

The integration currently pins frontend release `20250128065759` in `scripts/install/frontend`. After both PRs merge, a new frontend release must be published and that pin must be bumped before the integration release. Until then, merging this PR alone does not ship the frontend change to HACS users.

Related issues and PRs: hacs/integration#5171, hacs/integration#5179, hacs/integration#5223, and earlier installed-only approaches #937 / #929.

## Verification

- [x] Prettier passes for `src/dashboards/hacs-dashboard.ts`.
- [ ] Full dependency-based build: blocked before compilation because the repository pins the unavailable `tsparticles-preset-links@2.12.0` package; the same dependency is present on `main`.
